### PR TITLE
Drop references

### DIFF
--- a/src/zabbix_enums/common/__init__.py
+++ b/src/zabbix_enums/common/__init__.py
@@ -1,11 +1,6 @@
 from enum import IntEnum
 
 
-class _YesNo(IntEnum):
-    YES = 0
-    NO = 1
-
-
 class _DiscoveryFlag(IntEnum):
     PLAIN = 0
     DISCOVERED = 4

--- a/src/zabbix_enums/common/__init__.py
+++ b/src/zabbix_enums/common/__init__.py
@@ -1,11 +1,6 @@
 from enum import IntEnum
 
 
-class _DiscoveryFlag(IntEnum):
-    PLAIN = 0
-    DISCOVERED = 4
-
-
 class _EntityStatus(IntEnum):
     ENABLED = 0
     DISABLED = 1

--- a/src/zabbix_enums/common/__init__.py
+++ b/src/zabbix_enums/common/__init__.py
@@ -6,15 +6,6 @@ class _EntityStatus(IntEnum):
     DISABLED = 1
 
 
-class _Priority(IntEnum):
-    NOT_CLASSIFIED = 0
-    INFORMATION = 1
-    WARNING = 2
-    AVERAGE = 3
-    HIGH = 4
-    DISASTER = 5
-
-
 class _PrototypeDiscover(IntEnum):
     DISCOVER = 0
     DONT_DISCOVER = 1

--- a/src/zabbix_enums/common/__init__.py
+++ b/src/zabbix_enums/common/__init__.py
@@ -20,11 +20,6 @@ class _Priority(IntEnum):
     DISASTER = 5
 
 
-class _Suppressed(IntEnum):
-    NO = 0
-    YES = 1
-
-
 class _ObjectTrigger(IntEnum):
     TRIGGER = 0
 
@@ -38,13 +33,6 @@ class _ObjectInternal(IntEnum):
 class _PrototypeDiscover(IntEnum):
     DISCOVER = 0
     DONT_DISCOVER = 1
-
-
-class _ObjectSource(IntEnum):
-    TRIGGER = 0
-    DISCOVERY = 1
-    AUTOREGISTRATION = 2
-    INTERNAL = 3
 
 
 from .alert import *

--- a/src/zabbix_enums/common/__init__.py
+++ b/src/zabbix_enums/common/__init__.py
@@ -6,11 +6,6 @@ class _EntityStatus(IntEnum):
     DISABLED = 1
 
 
-class _PrototypeDiscover(IntEnum):
-    DISCOVER = 0
-    DONT_DISCOVER = 1
-
-
 from .alert import *
 from .audit_log import *
 from .dashboard import *

--- a/src/zabbix_enums/common/__init__.py
+++ b/src/zabbix_enums/common/__init__.py
@@ -1,11 +1,3 @@
-from enum import IntEnum
-
-
-class _EntityStatus(IntEnum):
-    ENABLED = 0
-    DISABLED = 1
-
-
 from .alert import *
 from .audit_log import *
 from .dashboard import *

--- a/src/zabbix_enums/common/__init__.py
+++ b/src/zabbix_enums/common/__init__.py
@@ -20,16 +20,6 @@ class _Priority(IntEnum):
     DISASTER = 5
 
 
-class _ObjectTrigger(IntEnum):
-    TRIGGER = 0
-
-
-class _ObjectInternal(IntEnum):
-    TRIGGER = 0
-    ITEM = 4
-    LLD = 5
-
-
 class _PrototypeDiscover(IntEnum):
     DISCOVER = 0
     DONT_DISCOVER = 1

--- a/src/zabbix_enums/common/__init__.py
+++ b/src/zabbix_enums/common/__init__.py
@@ -6,11 +6,6 @@ class _EntityStatus(IntEnum):
     DISABLED = 1
 
 
-class _Permission(IntEnum):
-    READ_ONLY = 2
-    READ_WRITE = 3
-
-
 class _Priority(IntEnum):
     NOT_CLASSIFIED = 0
     INFORMATION = 1

--- a/src/zabbix_enums/common/__init__.py
+++ b/src/zabbix_enums/common/__init__.py
@@ -1,11 +1,6 @@
 from enum import IntEnum
 
 
-class _NoYes(IntEnum):
-    NO = 0
-    YES = 1
-
-
 class _YesNo(IntEnum):
     YES = 0
     NO = 1

--- a/src/zabbix_enums/common/dashboard.py
+++ b/src/zabbix_enums/common/dashboard.py
@@ -1,13 +1,20 @@
 from enum import IntEnum
-from . import _Permission
 
 
 class DashboardPrivate(IntEnum):
     NO = 0
     YES = 1
 
-DashboardUserGroupPermission = _Permission
-DashboardUserPermission = _Permission
+
+class DashboardUserGroupPermission(IntEnum):
+    READ_ONLY = 2
+    READ_WRITE = 3
+
+
+class DashboardUserPermission(IntEnum):
+    READ_ONLY = 2
+    READ_WRITE = 3
+
 
 class DashboardWidgetHeaderHidden(IntEnum):
     NO = 0

--- a/src/zabbix_enums/common/dashboard.py
+++ b/src/zabbix_enums/common/dashboard.py
@@ -1,11 +1,17 @@
 from enum import IntEnum
-from . import _NoYes, _Permission
+from . import _Permission
 
 
-DashboardPrivate = _NoYes
+class DashboardPrivate(IntEnum):
+    NO = 0
+    YES = 1
+
 DashboardUserGroupPermission = _Permission
 DashboardUserPermission = _Permission
-DashboardWidgetHeaderHidden = _NoYes
+
+class DashboardWidgetHeaderHidden(IntEnum):
+    NO = 0
+    YES = 1
 
 
 class DashboardWidgetField(IntEnum):

--- a/src/zabbix_enums/common/discovery_check.py
+++ b/src/zabbix_enums/common/discovery_check.py
@@ -1,8 +1,9 @@
 from enum import IntEnum
-from . import _NoYes
 
 
-DiscoveryCheckUniq = _NoYes
+class DiscoveryCheckUniq(IntEnum):
+    NO = 0
+    YES = 1
 
 
 class DiscoveryCheckType(IntEnum):

--- a/src/zabbix_enums/common/discovery_rule.py
+++ b/src/zabbix_enums/common/discovery_rule.py
@@ -1,3 +1,6 @@
-from . import _EntityStatus
+from enum import IntEnum
 
-DiscoveryRuleStatus = _EntityStatus
+
+class DiscoveryRuleStatus(IntEnum):
+    ENABLED = 0
+    DISABLED = 1

--- a/src/zabbix_enums/common/event.py
+++ b/src/zabbix_enums/common/event.py
@@ -1,8 +1,13 @@
 from enum import IntEnum
-from . import _Priority
 
 
-EventSeverity = _Priority
+class EventSeverity(IntEnum):
+    NOT_CLASSIFIED = 0
+    INFORMATION = 1
+    WARNING = 2
+    AVERAGE = 3
+    HIGH = 4
+    DISASTER = 5
 
 
 class EventSuppressed(IntEnum):

--- a/src/zabbix_enums/common/event.py
+++ b/src/zabbix_enums/common/event.py
@@ -1,12 +1,24 @@
 from enum import IntEnum
-from . import _Priority, _Suppressed, _ObjectTrigger, _ObjectInternal, _ObjectSource
+from . import _Priority, _ObjectTrigger, _ObjectInternal
 
 
 EventSeverity = _Priority
-EventSuppressed = _Suppressed
+
+
+class EventSuppressed(IntEnum):
+    NO = 0
+    YES = 1
+
+
 EventObjectTrigger = _ObjectTrigger
 EventObjectInternal = _ObjectInternal
-EventSource = _ObjectSource
+
+
+class EventSource(IntEnum):
+    TRIGGER = 0
+    DISCOVERY = 1
+    AUTOREGISTRATION = 2
+    INTERNAL = 3
 
 
 class EventObjectDiscovery(IntEnum):

--- a/src/zabbix_enums/common/event.py
+++ b/src/zabbix_enums/common/event.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from . import _Priority, _ObjectTrigger, _ObjectInternal
+from . import _Priority
 
 
 EventSeverity = _Priority
@@ -10,8 +10,14 @@ class EventSuppressed(IntEnum):
     YES = 1
 
 
-EventObjectTrigger = _ObjectTrigger
-EventObjectInternal = _ObjectInternal
+class EventObjectTrigger(IntEnum):
+    TRIGGER = 0
+
+
+class EventObjectInternal(IntEnum):
+    TRIGGER = 0
+    ITEM = 4
+    LLD = 5
 
 
 class EventSource(IntEnum):

--- a/src/zabbix_enums/common/graph.py
+++ b/src/zabbix_enums/common/graph.py
@@ -1,12 +1,28 @@
 from enum import IntEnum
-from . import _DiscoveryFlag, _NoYes
+from . import _DiscoveryFlag
 
 
 GraphFlag = _DiscoveryFlag
-GraphShow3d = _NoYes
-GraphShowLegend = _NoYes
-GraphShowWorkPeriod = _NoYes
-GraphShowTriggers = _NoYes
+
+
+class GraphShow3d(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class GraphShowLegend(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class GraphShowWorkPeriod(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class GraphShowTriggers(IntEnum):
+    NO = 0
+    YES = 1
 
 
 class GraphType(IntEnum):

--- a/src/zabbix_enums/common/graph.py
+++ b/src/zabbix_enums/common/graph.py
@@ -1,8 +1,9 @@
 from enum import IntEnum
-from . import _DiscoveryFlag
 
 
-GraphFlag = _DiscoveryFlag
+class GraphFlag(IntEnum):
+    PLAIN = 0
+    DISCOVERED = 4
 
 
 class GraphShow3d(IntEnum):

--- a/src/zabbix_enums/common/graph.py
+++ b/src/zabbix_enums/common/graph.py
@@ -38,4 +38,8 @@ class GraphYmaxType(IntEnum):
     FIXED = 1
     ITEMS = 2
 
-GraphYminType = GraphYmaxType
+
+class GraphYminType(IntEnum):
+    CALCULATED = 0
+    FIXED = 1
+    ITEMS = 2

--- a/src/zabbix_enums/common/graph_prototype.py
+++ b/src/zabbix_enums/common/graph_prototype.py
@@ -1,11 +1,27 @@
-from . import _PrototypeDiscover, _NoYes
+from . import _PrototypeDiscover
 from .graph import *
 
 
-GraphPrototypeShow3d = _NoYes
-GraphPrototypeShowLegend = _NoYes
-GraphPrototypeShowWorkPeriod = _NoYes
-GraphPrototypeShowTriggers = _NoYes
+class GraphPrototypeShow3d(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class GraphPrototypeShowLegend(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class GraphPrototypeShowWorkPeriod(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class GraphPrototypeShowTriggers(IntEnum):
+    NO = 0
+    YES = 1
+
+
 GraphPrototypeType = GraphType
 GraphPrototypeYmaxType = GraphYmaxType
 GraphPrototypeYminType = GraphPrototypeYmaxType

--- a/src/zabbix_enums/common/graph_prototype.py
+++ b/src/zabbix_enums/common/graph_prototype.py
@@ -1,29 +1,13 @@
 from .graph import *
 
 
-class GraphPrototypeShow3d(IntEnum):
-    NO = 0
-    YES = 1
-
-
-class GraphPrototypeShowLegend(IntEnum):
-    NO = 0
-    YES = 1
-
-
-class GraphPrototypeShowWorkPeriod(IntEnum):
-    NO = 0
-    YES = 1
-
-
-class GraphPrototypeShowTriggers(IntEnum):
-    NO = 0
-    YES = 1
-
-
+GraphPrototypeShow3d = GraphShow3d
+GraphPrototypeShowLegend = GraphShowLegend
+GraphPrototypeShowWorkPeriod = GraphShowWorkPeriod
+GraphPrototypeShowTriggers = GraphShowTriggers
 GraphPrototypeType = GraphType
 GraphPrototypeYmaxType = GraphYmaxType
-GraphPrototypeYminType = GraphPrototypeYmaxType
+GraphPrototypeYminType = GraphYminType
 
 
 class GrapPrototypeDiscover(IntEnum):

--- a/src/zabbix_enums/common/graph_prototype.py
+++ b/src/zabbix_enums/common/graph_prototype.py
@@ -1,4 +1,3 @@
-from . import _PrototypeDiscover
 from .graph import *
 
 
@@ -25,4 +24,8 @@ class GraphPrototypeShowTriggers(IntEnum):
 GraphPrototypeType = GraphType
 GraphPrototypeYmaxType = GraphYmaxType
 GraphPrototypeYminType = GraphPrototypeYmaxType
-GrapPrototypeDiscover = _PrototypeDiscover
+
+
+class GrapPrototypeDiscover(IntEnum):
+    DISCOVER = 0
+    DONT_DISCOVER = 1

--- a/src/zabbix_enums/common/host.py
+++ b/src/zabbix_enums/common/host.py
@@ -1,8 +1,10 @@
 from enum import IntEnum
-from . import _DiscoveryFlag
 
 
-HostFlag = _DiscoveryFlag
+class HostFlag(IntEnum):
+    PLAIN = 0
+    DISCOVERED = 4
+
 
 
 class HostInventoryMode(IntEnum):

--- a/src/zabbix_enums/common/host_group.py
+++ b/src/zabbix_enums/common/host_group.py
@@ -1,5 +1,10 @@
-from . import _DiscoveryFlag, _NoYes
+from enum import IntEnum
+from . import _DiscoveryFlag
 
 
 HostGroupFlag = _DiscoveryFlag
-HostGroupInternal = _NoYes
+
+
+class HostGroupInternal(IntEnum):
+    NO = 0
+    YES = 1

--- a/src/zabbix_enums/common/host_group.py
+++ b/src/zabbix_enums/common/host_group.py
@@ -1,8 +1,9 @@
 from enum import IntEnum
-from . import _DiscoveryFlag
 
 
-HostGroupFlag = _DiscoveryFlag
+class HostGroupFlag(IntEnum):
+    PLAIN = 0
+    DISCOVERED = 4
 
 
 class HostGroupInternal(IntEnum):

--- a/src/zabbix_enums/common/host_interface.py
+++ b/src/zabbix_enums/common/host_interface.py
@@ -1,9 +1,14 @@
 from enum import IntEnum
-from . import _NoYes
 
 
-HostInterfaceMain = _NoYes
-HostIntrefaceUseIP = _NoYes
+class HostInterfaceMain(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class HostIntrefaceUseIP(IntEnum):
+    NO = 0
+    YES = 1
 
 
 class HostInterfaceType(IntEnum):

--- a/src/zabbix_enums/common/host_prototype.py
+++ b/src/zabbix_enums/common/host_prototype.py
@@ -1,6 +1,11 @@
+from enum import IntEnum
 from .host import HostStatus, HostInventoryMode
-from . import _PrototypeDiscover
+
 
 HostPrototypeStatus = HostStatus
 HostPrototypeInventoryMode = HostInventoryMode
-HostPrototypeDiscover = _PrototypeDiscover
+
+
+class HostPrototypeDiscover(IntEnum):
+    DISCOVER = 0
+    DONT_DISCOVER = 1

--- a/src/zabbix_enums/common/item.py
+++ b/src/zabbix_enums/common/item.py
@@ -1,5 +1,4 @@
 from enum import IntEnum
-from . import _EntityStatus
 
 
 class ItemFlag(IntEnum):
@@ -7,7 +6,9 @@ class ItemFlag(IntEnum):
     DISCOVERED = 4
 
 
-ItemStatus = _EntityStatus
+class ItemStatus(IntEnum):
+    ENABLED = 0
+    DISABLED = 1
 
 
 class ItemValueType(IntEnum):

--- a/src/zabbix_enums/common/item.py
+++ b/src/zabbix_enums/common/item.py
@@ -1,8 +1,12 @@
 from enum import IntEnum
-from . import _DiscoveryFlag, _EntityStatus
+from . import _EntityStatus
 
 
-ItemFlag = _DiscoveryFlag
+class ItemFlag(IntEnum):
+    PLAIN = 0
+    DISCOVERED = 4
+
+
 ItemStatus = _EntityStatus
 
 

--- a/src/zabbix_enums/common/item_http.py
+++ b/src/zabbix_enums/common/item_http.py
@@ -1,11 +1,24 @@
 from enum import IntEnum
-from . import _NoYes
 
 
-ItemAllowTraps = _NoYes
-ItemFollowRedirects = _NoYes
-ItemVerifyHost = _NoYes
-ItemVerifyPeer = _NoYes
+class ItemAllowTraps(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class ItemFollowRedirects(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class ItemVerifyHost(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class ItemVerifyPeer(IntEnum):
+    NO = 0
+    YES = 1
 
 
 class ItemAuthTypeHTTP(IntEnum):

--- a/src/zabbix_enums/common/item_prototype.py
+++ b/src/zabbix_enums/common/item_prototype.py
@@ -1,12 +1,9 @@
 from enum import IntEnum
-
+from .item import ItemStatus
 
 class ItemPrototypeDiscover(IntEnum):
     DISCOVER = 0
     DONT_DISCOVER = 1
 
 
-class ItemPrototypeStatus(IntEnum):
-    ENABLED = 0
-    DISABLED = 1
-    UNSUPPORTED = 3
+ItemPrototypeStatus = ItemStatus

--- a/src/zabbix_enums/common/item_prototype.py
+++ b/src/zabbix_enums/common/item_prototype.py
@@ -1,8 +1,9 @@
 from enum import IntEnum
-from . import _PrototypeDiscover
 
 
-ItemPrototypeDiscover = _PrototypeDiscover
+class ItemPrototypeDiscover(IntEnum):
+    DISCOVER = 0
+    DONT_DISCOVER = 1
 
 
 class ItemPrototypeStatus(IntEnum):

--- a/src/zabbix_enums/common/lld.py
+++ b/src/zabbix_enums/common/lld.py
@@ -1,12 +1,15 @@
 from enum import IntEnum
-from . import _EntityStatus
 from .item import ItemAuthTypeSSH
 from .item_http import *
 from .item_preprocessing import PreprocessingErrorHandler
 from .host import HostInventoryMode
 
 
-LLDStatus = _EntityStatus
+class LLDStatus(IntEnum):
+    ENABLED = 0
+    DISABLED = 1
+
+
 LLDRuleAllowTraps = ItemAllowTraps
 LLDRuleAuthTypeHTTP = ItemAuthTypeHTTP
 LLDRuleAuthTypeSSH = ItemAuthTypeSSH
@@ -15,7 +18,13 @@ LLDRuleOutputFormat = ItemOutputFormat
 LLDRulePostType = ItemPostType
 LLDRuleRequestMethod = ItemRequestMethod
 LLDRuleRetrieveMode = ItemRetrieveMode
-LLDRuleStatus = _EntityStatus
+
+
+class LLDRuleStatus(IntEnum):
+    ENABLED = 0
+    DISABLED = 1
+
+
 LLDRuleVerifyHost = ItemVerifyHost
 LLDRuleVerifyPeer = ItemVerifyPeer
 

--- a/src/zabbix_enums/common/lld.py
+++ b/src/zabbix_enums/common/lld.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from . import _EntityStatus, _YesNo, _Priority
+from . import _EntityStatus, _Priority
 from .item import ItemAuthTypeSSH
 from .item_http import *
 from .item_preprocessing import PreprocessingErrorHandler
@@ -37,7 +37,13 @@ class LLDRuleOverridesStop(IntEnum):
 
 
 LLDRuleOverrideEvalType = LLDRuleEvalType
-LLDRuleOverrideOperationDiscover = _YesNo
+
+
+class LLDRuleOverrideOperationDiscover(IntEnum):
+    YES = 0
+    NO = 1
+
+
 LLDRuleOverrideOperationSeverity = _Priority
 LLDRuleOverrideOperationInventory = HostInventoryMode
 

--- a/src/zabbix_enums/common/lld.py
+++ b/src/zabbix_enums/common/lld.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from . import _EntityStatus, _NoYes, _YesNo, _Priority
+from . import _EntityStatus, _YesNo, _Priority
 from .item import ItemAuthTypeSSH
 from .item_http import *
 from .item_preprocessing import PreprocessingErrorHandler
@@ -29,7 +29,13 @@ class LLDRuleEvalType(IntEnum):
 
 
 LLDRulePreprocessingErrorHandler = PreprocessingErrorHandler
-LLDRuleOverridesStop = _NoYes
+
+
+class LLDRuleOverridesStop(IntEnum):
+    NO = 0
+    YES = 1
+
+
 LLDRuleOverrideEvalType = LLDRuleEvalType
 LLDRuleOverrideOperationDiscover = _YesNo
 LLDRuleOverrideOperationSeverity = _Priority

--- a/src/zabbix_enums/common/lld.py
+++ b/src/zabbix_enums/common/lld.py
@@ -1,8 +1,4 @@
 from enum import IntEnum
-from .item import ItemAuthTypeSSH
-from .item_http import *
-from .item_preprocessing import PreprocessingErrorHandler
-from .host import HostInventoryMode
 
 
 class LLDStatus(IntEnum):
@@ -10,14 +6,51 @@ class LLDStatus(IntEnum):
     DISABLED = 1
 
 
-LLDRuleAllowTraps = ItemAllowTraps
-LLDRuleAuthTypeHTTP = ItemAuthTypeHTTP
-LLDRuleAuthTypeSSH = ItemAuthTypeSSH
-LLDRuleFollowRedirects = ItemFollowRedirects
-LLDRuleOutputFormat = ItemOutputFormat
-LLDRulePostType = ItemPostType
-LLDRuleRequestMethod = ItemRequestMethod
-LLDRuleRetrieveMode = ItemRetrieveMode
+class LLDRuleAllowTraps(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class LLDRuleAuthTypeHTTP(IntEnum):
+    NONE = 0
+    BASIC = 1
+    NTLM = 2
+    KERBEROS = 3
+
+
+class LLDRuleAuthTypeSSH(IntEnum):
+    PASSWORD = 0
+    PUBLIC_KEY = 1
+
+
+class LLDRuleFollowRedirects(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class LLDRuleOutputFormat(IntEnum):
+    RAW = 0
+    JSON = 1
+
+
+class LLDRulePostType(IntEnum):
+    RAW = 0
+    JSON = 2
+    XML = 3
+
+
+class LLDRuleRequestMethod(IntEnum):
+    GET = 0
+    POST = 1
+    PUT = 2
+    HEAD  = 3
+
+
+class LLDRuleRetrieveMode(IntEnum):
+    BODY = 0
+    HEADERS = 1
+    BODY_AND_HEADERS = 2
+    BOTH = 2
 
 
 class LLDRuleStatus(IntEnum):
@@ -25,9 +58,14 @@ class LLDRuleStatus(IntEnum):
     DISABLED = 1
 
 
-LLDRuleVerifyHost = ItemVerifyHost
-LLDRuleVerifyPeer = ItemVerifyPeer
+class LLDRuleVerifyHost(IntEnum):
+    NO = 0
+    YES = 1
 
+
+class LLDRuleVerifyPeer(IntEnum):
+    NO = 0
+    YES = 1
 
 
 class LLDRuleEvalType(IntEnum):
@@ -37,7 +75,11 @@ class LLDRuleEvalType(IntEnum):
     CUSTOM = 3
 
 
-LLDRulePreprocessingErrorHandler = PreprocessingErrorHandler
+class LLDRulePreprocessingErrorHandler(IntEnum):
+    ERROR_MESSAGE = 0
+    DISCARD_VALUE = 1
+    CUSTOM_VALUE = 2
+    CUSTOM_ERROR_MESSAGE = 3
 
 
 class LLDRuleOverridesStop(IntEnum):
@@ -45,7 +87,11 @@ class LLDRuleOverridesStop(IntEnum):
     YES = 1
 
 
-LLDRuleOverrideEvalType = LLDRuleEvalType
+class LLDRuleOverrideEvalType(IntEnum):
+    AND_OR = 0
+    AND = 1
+    OR = 2
+    CUSTOM = 3
 
 
 class LLDRuleOverrideOperationDiscover(IntEnum):
@@ -62,7 +108,10 @@ class LLDRuleOverrideOperationSeverity(IntEnum):
     DISASTER = 5
 
 
-LLDRuleOverrideOperationInventory = HostInventoryMode
+class LLDRuleOverrideOperationInventory(IntEnum):
+    DISABLED = -1
+    MANUAL = 0
+    AUTOMATIC = 1
 
 
 class LLDRuleOverrideOperationObject(IntEnum):

--- a/src/zabbix_enums/common/lld.py
+++ b/src/zabbix_enums/common/lld.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from . import _EntityStatus, _Priority
+from . import _EntityStatus
 from .item import ItemAuthTypeSSH
 from .item_http import *
 from .item_preprocessing import PreprocessingErrorHandler
@@ -44,7 +44,15 @@ class LLDRuleOverrideOperationDiscover(IntEnum):
     NO = 1
 
 
-LLDRuleOverrideOperationSeverity = _Priority
+class LLDRuleOverrideOperationSeverity(IntEnum):
+    NOT_CLASSIFIED = 0
+    INFORMATION = 1
+    WARNING = 2
+    AVERAGE = 3
+    HIGH = 4
+    DISASTER = 5
+
+
 LLDRuleOverrideOperationInventory = HostInventoryMode
 
 

--- a/src/zabbix_enums/common/map.py
+++ b/src/zabbix_enums/common/map.py
@@ -1,13 +1,34 @@
 from enum import IntEnum
-from . import _NoYes
 
 
-MapExpandMacro = _NoYes
-MapExpandProblem = _NoYes
-MapGridAlignEnable = _NoYes
-MapGridShow = _NoYes
-MapHighlightEnable = _NoYes
-MapMarkElements = _NoYes
+class MapExpandMacro(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class MapExpandProblem(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class MapGridAlignEnable(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class MapGridShow(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class MapHighlightEnable(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class MapMarkElements(IntEnum):
+    NO = 0
+    YES = 1
 
 
 class MapLabelType(IntEnum):

--- a/src/zabbix_enums/common/media_type.py
+++ b/src/zabbix_enums/common/media_type.py
@@ -1,5 +1,4 @@
 from enum import IntEnum
-from . import _EntityStatus
 
 
 class MediaTypeSMTPSVerifyHost(IntEnum):
@@ -12,7 +11,9 @@ class MediaTypeSMTPSVerifyPeer(IntEnum):
     YES = 1
 
 
-MediaTypeStatus = _EntityStatus
+class MediaTypeStatus(IntEnum):
+    ENABLED = 0
+    DISABLED = 1
 
 
 class MediaTypeProcessTags(IntEnum):

--- a/src/zabbix_enums/common/media_type.py
+++ b/src/zabbix_enums/common/media_type.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from . import _EntityStatus, _ObjectSource
+from . import _EntityStatus
 
 
 class MediaTypeSMTPSVerifyHost(IntEnum):
@@ -25,7 +25,11 @@ class MediaTypeShowEventMenu(IntEnum):
     YES = 1
 
 
-MediaTypeEventSource = _ObjectSource
+class MediaTypeEventSource(IntEnum):
+    TRIGGER = 0
+    DISCOVERY = 1
+    AUTOREGISTRATION = 2
+    INTERNAL = 3
 
 
 class MediaType(IntEnum):

--- a/src/zabbix_enums/common/media_type.py
+++ b/src/zabbix_enums/common/media_type.py
@@ -1,12 +1,30 @@
 from enum import IntEnum
-from . import _NoYes, _EntityStatus, _ObjectSource
+from . import _EntityStatus, _ObjectSource
 
 
-MediaTypeSMTPSVerifyHost = _NoYes
-MediaTypeSMTPSVerifyPeer = _NoYes
+class MediaTypeSMTPSVerifyHost(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class MediaTypeSMTPSVerifyPeer(IntEnum):
+    NO = 0
+    YES = 1
+
+
 MediaTypeStatus = _EntityStatus
-MediaTypeProcessTags = _NoYes
-MediaTypeShowEventMenu = _NoYes
+
+
+class MediaTypeProcessTags(IntEnum):
+    NO = 0
+    YES = 1
+
+
+class MediaTypeShowEventMenu(IntEnum):
+    NO = 0
+    YES = 1
+
+
 MediaTypeEventSource = _ObjectSource
 
 

--- a/src/zabbix_enums/common/problem.py
+++ b/src/zabbix_enums/common/problem.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from . import _Priority, _ObjectTrigger, _ObjectInternal
+from . import _Priority
 
 
 ProblemSeverity = _Priority
@@ -10,8 +10,14 @@ class ProblemSuppressed(IntEnum):
     YES = 1
 
 
-ProblemObjectTrigger = _ObjectTrigger
-ProblemObjectInternal = _ObjectInternal
+class ProblemObjectTrigger(IntEnum):
+    TRIGGER = 0
+
+
+class ProblemObjectInternal(IntEnum):
+    TRIGGER = 0
+    ITEM = 4
+    LLD = 5
 
 
 class ProblemAcknowledged(IntEnum):

--- a/src/zabbix_enums/common/problem.py
+++ b/src/zabbix_enums/common/problem.py
@@ -1,9 +1,15 @@
 from enum import IntEnum
-from . import _Priority, _Suppressed, _ObjectTrigger, _ObjectInternal
+from . import _Priority, _ObjectTrigger, _ObjectInternal
 
 
 ProblemSeverity = _Priority
-ProblemSuppressed = _Suppressed
+
+
+class ProblemSuppressed(IntEnum):
+    NO = 0
+    YES = 1
+
+
 ProblemObjectTrigger = _ObjectTrigger
 ProblemObjectInternal = _ObjectInternal
 

--- a/src/zabbix_enums/common/problem.py
+++ b/src/zabbix_enums/common/problem.py
@@ -1,8 +1,13 @@
 from enum import IntEnum
-from . import _Priority
 
 
-ProblemSeverity = _Priority
+class ProblemSeverity(IntEnum):
+    NOT_CLASSIFIED = 0
+    INFORMATION = 1
+    WARNING = 2
+    AVERAGE = 3
+    HIGH = 4
+    DISASTER = 5
 
 
 class ProblemSuppressed(IntEnum):

--- a/src/zabbix_enums/common/proxy.py
+++ b/src/zabbix_enums/common/proxy.py
@@ -5,7 +5,10 @@ class ProxyStatus(IntEnum):
     ACTIVE = 5
     PASSIVE = 6
 
-ProxyType = ProxyStatus
+
+class ProxyType(IntEnum):
+    ACTIVE = 5
+    PASSIVE = 6
 
 
 class ProxyUseIp(IntEnum):

--- a/src/zabbix_enums/common/proxy.py
+++ b/src/zabbix_enums/common/proxy.py
@@ -1,5 +1,4 @@
 from enum import IntEnum
-from . import _NoYes
 
 
 class ProxyStatus(IntEnum):
@@ -7,4 +6,8 @@ class ProxyStatus(IntEnum):
     PASSIVE = 6
 
 ProxyType = ProxyStatus
-ProxyUseIp = _NoYes
+
+
+class ProxyUseIp(IntEnum):
+    NO = 0
+    YES = 1

--- a/src/zabbix_enums/common/trigger.py
+++ b/src/zabbix_enums/common/trigger.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from . import _EntityStatus, _Priority
+from . import _EntityStatus
 
 
 class TriggerFlag(IntEnum):
@@ -8,7 +8,15 @@ class TriggerFlag(IntEnum):
 
 
 TriggerStatus = _EntityStatus
-TriggerPriority = _Priority
+
+
+class TriggerPriority(IntEnum):
+    NOT_CLASSIFIED = 0
+    INFORMATION = 1
+    WARNING = 2
+    AVERAGE = 3
+    HIGH = 4
+    DISASTER = 5
 
 
 class TriggerState(IntEnum):

--- a/src/zabbix_enums/common/trigger.py
+++ b/src/zabbix_enums/common/trigger.py
@@ -1,5 +1,4 @@
 from enum import IntEnum
-from . import _EntityStatus
 
 
 class TriggerFlag(IntEnum):
@@ -7,7 +6,9 @@ class TriggerFlag(IntEnum):
     DISCOVERED = 4
 
 
-TriggerStatus = _EntityStatus
+class TriggerStatus(IntEnum):
+    ENABLED = 0
+    DISABLED = 1
 
 
 class TriggerPriority(IntEnum):

--- a/src/zabbix_enums/common/trigger.py
+++ b/src/zabbix_enums/common/trigger.py
@@ -1,8 +1,12 @@
 from enum import IntEnum
-from . import _DiscoveryFlag, _EntityStatus, _Priority
+from . import _EntityStatus, _Priority
 
 
-TriggerFlag = _DiscoveryFlag
+class TriggerFlag(IntEnum):
+    PLAIN = 0
+    DISCOVERED = 4
+
+
 TriggerStatus = _EntityStatus
 TriggerPriority = _Priority
 

--- a/src/zabbix_enums/common/trigger_prototype.py
+++ b/src/zabbix_enums/common/trigger_prototype.py
@@ -1,5 +1,4 @@
 from .trigger import *
-from . import _EntityStatus
 
 
 class TriggerPrototypeFlag(IntEnum):
@@ -7,7 +6,9 @@ class TriggerPrototypeFlag(IntEnum):
     DISCOVERED = 4
 
 
-TriggerPrototypeStatus = _EntityStatus
+class TriggerPrototypeStatus(IntEnum):
+    ENABLED = 0
+    DISABLED = 1
 
 
 class TriggerPrototypePriority(IntEnum):

--- a/src/zabbix_enums/common/trigger_prototype.py
+++ b/src/zabbix_enums/common/trigger_prototype.py
@@ -1,5 +1,5 @@
 from .trigger import *
-from . import _EntityStatus, _Priority
+from . import _EntityStatus
 
 
 class TriggerPrototypeFlag(IntEnum):
@@ -8,7 +8,17 @@ class TriggerPrototypeFlag(IntEnum):
 
 
 TriggerPrototypeStatus = _EntityStatus
-TriggerPrototypePriority = _Priority
+
+
+class TriggerPrototypePriority(IntEnum):
+    NOT_CLASSIFIED = 0
+    INFORMATION = 1
+    WARNING = 2
+    AVERAGE = 3
+    HIGH = 4
+    DISASTER = 5
+
+
 TriggerPrototypeState = TriggerState
 TriggerPrototypeType = TriggerType
 TriggerPrototypeValue = TriggerValue

--- a/src/zabbix_enums/common/trigger_prototype.py
+++ b/src/zabbix_enums/common/trigger_prototype.py
@@ -6,20 +6,8 @@ class TriggerPrototypeFlag(IntEnum):
     DISCOVERED = 4
 
 
-class TriggerPrototypeStatus(IntEnum):
-    ENABLED = 0
-    DISABLED = 1
-
-
-class TriggerPrototypePriority(IntEnum):
-    NOT_CLASSIFIED = 0
-    INFORMATION = 1
-    WARNING = 2
-    AVERAGE = 3
-    HIGH = 4
-    DISASTER = 5
-
-
+TriggerPrototypeStatus = TriggerStatus
+TriggerPrototypePriority = TriggerPriority
 TriggerPrototypeState = TriggerState
 TriggerPrototypeType = TriggerType
 TriggerPrototypeValue = TriggerValue

--- a/src/zabbix_enums/common/trigger_prototype.py
+++ b/src/zabbix_enums/common/trigger_prototype.py
@@ -1,8 +1,12 @@
 from .trigger import *
-from . import _DiscoveryFlag, _EntityStatus, _Priority
+from . import _EntityStatus, _Priority
 
 
-TriggerPrototypeFlag = _DiscoveryFlag
+class TriggerPrototypeFlag(IntEnum):
+    PLAIN = 0
+    DISCOVERED = 4
+
+
 TriggerPrototypeStatus = _EntityStatus
 TriggerPrototypePriority = _Priority
 TriggerPrototypeState = TriggerState

--- a/src/zabbix_enums/specific/z54/dashboard.py
+++ b/src/zabbix_enums/specific/z54/dashboard.py
@@ -1,8 +1,9 @@
-from enum import Enum
-from zabbix_enums.common import _NoYes
+from enum import Enum, IntEnum
 
 
-DashboardStartSlideshow = _NoYes
+class DashboardStartSlideshow(IntEnum):
+    NO = 0
+    YES = 1
 
 
 class DashboardWidgetType(str, Enum):


### PR DESCRIPTION
The amount of references and aliases used is astounding.
Dropping them will make supporting new versions easier.